### PR TITLE
Fix a router issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         go:
-          - "1.22"
           - "1.23"
           - "1.24"
+          - "1.25"
 
     steps:
       - name: Checkout

--- a/web/router/router.go
+++ b/web/router/router.go
@@ -66,79 +66,83 @@ func (ro chiRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (ro chiRouter) Method(method string, path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(method, path, handler)
+	if len(mws) > 0 {
+		ro.chi.Method(method, path, chain(handler, mws...))
+	} else {
+		ro.chi.Method(method, path, handler)
+	}
 }
 
 func (ro chiRouter) Connect(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodConnect, path, handler)
+	ro.Method(http.MethodConnect, path, handler, mws...)
 }
 
 func (ro chiRouter) Connectf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodConnect, path, handler)
+	ro.Method(http.MethodConnect, path, handler, mws...)
 }
 
 func (ro chiRouter) Delete(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodDelete, path, handler)
+	ro.Method(http.MethodDelete, path, handler, mws...)
 }
 
 func (ro chiRouter) Deletef(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodDelete, path, handler)
+	ro.Method(http.MethodDelete, path, handler, mws...)
 }
 
 func (ro chiRouter) Get(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodGet, path, handler)
+	ro.Method(http.MethodGet, path, handler, mws...)
 }
 
 func (ro chiRouter) Getf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodGet, path, handler)
+	ro.Method(http.MethodGet, path, handler, mws...)
 }
 
 func (ro chiRouter) Head(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodHead, path, handler)
+	ro.Method(http.MethodHead, path, handler, mws...)
 }
 
 func (ro chiRouter) Headf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodHead, path, handler)
+	ro.Method(http.MethodHead, path, handler, mws...)
 }
 
 func (ro chiRouter) Options(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodOptions, path, handler)
+	ro.Method(http.MethodOptions, path, handler, mws...)
 }
 
 func (ro chiRouter) Optionsf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodOptions, path, handler)
+	ro.Method(http.MethodOptions, path, handler, mws...)
 }
 
 func (ro chiRouter) Patch(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPatch, path, handler)
+	ro.Method(http.MethodPatch, path, handler, mws...)
 }
 
 func (ro chiRouter) Patchf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPatch, path, handler)
+	ro.Method(http.MethodPatch, path, handler, mws...)
 }
 
 func (ro chiRouter) Post(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPost, path, handler)
+	ro.Method(http.MethodPost, path, handler, mws...)
 }
 
 func (ro chiRouter) Postf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPost, path, handler)
+	ro.Method(http.MethodPost, path, handler, mws...)
 }
 
 func (ro chiRouter) Put(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPut, path, handler)
+	ro.Method(http.MethodPut, path, handler, mws...)
 }
 
 func (ro chiRouter) Putf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPut, path, handler)
+	ro.Method(http.MethodPut, path, handler, mws...)
 }
 
 func (ro chiRouter) Trace(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodTrace, path, handler)
+	ro.Method(http.MethodTrace, path, handler, mws...)
 }
 
 func (ro chiRouter) Tracef(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodTrace, path, handler)
+	ro.Method(http.MethodTrace, path, handler, mws...)
 }
 
 func (ro chiRouter) Group(f func(Router), mws ...Middleware) {
@@ -178,4 +182,12 @@ func (ro chiRouter) Routes() []Route {
 		return nil
 	})
 	return tbr
+}
+
+// chain applies middlewares to a handler
+func chain(h http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
 }

--- a/web/router/router_test.go
+++ b/web/router/router_test.go
@@ -1,0 +1,122 @@
+package router_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jimmysawczuk/kit/web/router"
+)
+
+func TestRouteParamsWithMiddleware(t *testing.T) {
+	r := router.New()
+
+	// Middleware that does nothing
+	nopMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	var capturedID string
+
+	// Register route with middleware - this triggers the bug
+	r.Get("/users/{userID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This should extract "123" but returns "" due to bug
+		capturedID = chi.URLParam(r, "userID")
+		w.WriteHeader(http.StatusOK)
+	}), nopMiddleware)
+
+	req := httptest.NewRequest("GET", "/users/123", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	if capturedID != "123" {
+		t.Errorf("expected userID to be '123', got '%s'", capturedID)
+	}
+}
+
+func TestRouteParamsWithoutMiddleware(t *testing.T) {
+	r := router.New()
+
+	var capturedID string
+
+	// Register route WITHOUT middleware - this works fine
+	r.Get("/users/{userID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedID = chi.URLParam(r, "userID")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/users/456", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	if capturedID != "456" {
+		t.Errorf("expected userID to be '456', got '%s'", capturedID)
+	}
+}
+
+func TestNestedRouteParamsWithMiddleware(t *testing.T) {
+	r := router.New()
+
+	nopMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	var capturedSiteID, capturedRecipeID string
+
+	// Test nested routes like /v1/recipes/{siteID}/recipes/{recipeID}
+	r.Route("/v1/recipes", func(r router.Router) {
+		r.Get("/{siteID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedSiteID = chi.URLParam(r, "siteID")
+			w.WriteHeader(http.StatusOK)
+		}), nopMiddleware)
+
+		r.Get("/{siteID}/{recipeID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedSiteID = chi.URLParam(r, "siteID")
+			capturedRecipeID = chi.URLParam(r, "recipeID")
+			w.WriteHeader(http.StatusOK)
+		}), nopMiddleware)
+	})
+
+	// Test single param
+	req1 := httptest.NewRequest("GET", "/v1/recipes/site-abc", nil)
+	rec1 := httptest.NewRecorder()
+	r.ServeHTTP(rec1, req1)
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec1.Code)
+	}
+	if capturedSiteID != "site-abc" {
+		t.Errorf("expected siteID to be 'site-abc', got '%s'", capturedSiteID)
+	}
+
+	// Test multiple params
+	capturedSiteID, capturedRecipeID = "", ""
+	req2 := httptest.NewRequest("GET", "/v1/recipes/site-xyz/recipe-789", nil)
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec2.Code)
+	}
+	if capturedSiteID != "site-xyz" {
+		t.Errorf("expected siteID to be 'site-xyz', got '%s'", capturedSiteID)
+	}
+	if capturedRecipeID != "recipe-789" {
+		t.Errorf("expected recipeID to be 'recipe-789', got '%s'", capturedRecipeID)
+	}
+}


### PR DESCRIPTION
# Router Wrapper Bug: Chi Route Context Not Set When Using Middlewares

## Summary

The router wrapper in `github.com/jimmysawczuk/kit/web/router` has a bug where chi's route context is not properly set up when registering routes with middlewares. This prevents `chi.URLParam()` from extracting URL parameters, causing handlers to receive empty strings for route parameters.

## Root Cause

The bug is in how the wrapper handles route registration with middlewares. The current implementation:

```go
func (ro chiRouter) Get(path string, handler http.Handler, mws ...Middleware) {
	ro.chi.With(mws...).Method(http.MethodGet, path, handler)
}
```

This calls `ro.chi.With(mws...)` which creates a **temporary router branch** with those middlewares. The route is then registered on this temporary branch via `.Method()`, but since the branch is not stored anywhere, it gets discarded. Chi never sees the route registered on the main router, so it doesn't set up route context properly.

## Impact

When routes are registered with per-route middlewares:
- `chi.URLParam(r, "paramName")` returns empty string
- `chi.RouteContext(r.Context())` returns `nil`
- Route matching works (handlers are called), but parameter extraction fails

Routes registered **without** per-route middlewares work fine because they call the direct chi methods.

## The Fix

Instead of using chi's `.With()` to create a temporary branch, manually chain the middlewares and register directly on the main router:

```diff
func (ro chiRouter) Method(method string, path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(method, path, handler)
+	if len(mws) > 0 {
+		ro.chi.Method(method, path, chain(handler, mws...))
+	} else {
+		ro.chi.Method(method, path, handler)
+	}
}

func (ro chiRouter) Connect(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodConnect, path, handler)
+	ro.Method(http.MethodConnect, path, handler, mws...)
}

func (ro chiRouter) Connectf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodConnect, path, handler)
+	ro.Method(http.MethodConnect, path, handler, mws...)
}

func (ro chiRouter) Delete(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodDelete, path, handler)
+	ro.Method(http.MethodDelete, path, handler, mws...)
}

func (ro chiRouter) Deletef(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodDelete, path, handler)
+	ro.Method(http.MethodDelete, path, handler, mws...)
}

func (ro chiRouter) Get(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodGet, path, handler)
+	ro.Method(http.MethodGet, path, handler, mws...)
}

func (ro chiRouter) Getf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodGet, path, handler)
+	ro.Method(http.MethodGet, path, handler, mws...)
}

func (ro chiRouter) Head(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodHead, path, handler)
+	ro.Method(http.MethodHead, path, handler, mws...)
}

func (ro chiRouter) Headf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodHead, path, handler)
+	ro.Method(http.MethodHead, path, handler, mws...)
}

func (ro chiRouter) Options(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodOptions, path, handler)
+	ro.Method(http.MethodOptions, path, handler, mws...)
}

func (ro chiRouter) Optionsf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodOptions, path, handler)
+	ro.Method(http.MethodOptions, path, handler, mws...)
}

func (ro chiRouter) Patch(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPatch, path, handler)
+	ro.Method(http.MethodPatch, path, handler, mws...)
}

func (ro chiRouter) Patchf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPatch, path, handler)
+	ro.Method(http.MethodPatch, path, handler, mws...)
}

func (ro chiRouter) Post(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPost, path, handler)
+	ro.Method(http.MethodPost, path, handler, mws...)
}

func (ro chiRouter) Postf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPost, path, handler)
+	ro.Method(http.MethodPost, path, handler, mws...)
}

func (ro chiRouter) Put(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPut, path, handler)
+	ro.Method(http.MethodPut, path, handler, mws...)
}

func (ro chiRouter) Putf(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodPut, path, handler)
+	ro.Method(http.MethodPut, path, handler, mws...)
}

func (ro chiRouter) Trace(path string, handler http.Handler, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodTrace, path, handler)
+	ro.Method(http.MethodTrace, path, handler, mws...)
}

func (ro chiRouter) Tracef(path string, handler http.HandlerFunc, mws ...Middleware) {
-	ro.chi.With(mws...).Method(http.MethodTrace, path, handler)
+	ro.Method(http.MethodTrace, path, handler, mws...)
+}
+
+// chain applies middlewares to a handler
+func chain(h http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
}
```

## Test Case

This test case reproduces the bug. Without the fix, it will fail because `chi.URLParam()` returns an empty string.

```go
package router_test

import (
	"context"
	"net/http"
	"net/http/httptest"
	"testing"

	"github.com/go-chi/chi/v5"
	"github.com/jimmysawczuk/kit/web/router"
)

func TestRouteParamsWithMiddleware(t *testing.T) {
	r := router.New()

	// Middleware that does nothing
	nopMiddleware := func(next http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			next.ServeHTTP(w, r)
		})
	}

	var capturedID string

	// Register route with middleware - this triggers the bug
	r.Get("/users/{userID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		// This should extract "123" but returns "" due to bug
		capturedID = chi.URLParam(r, "userID")
		w.WriteHeader(http.StatusOK)
	}), nopMiddleware)

	req := httptest.NewRequest("GET", "/users/123", nil)
	rec := httptest.NewRecorder()

	r.ServeHTTP(rec, req)

	if rec.Code != http.StatusOK {
		t.Fatalf("expected status 200, got %d", rec.Code)
	}

	if capturedID != "123" {
		t.Errorf("expected userID to be '123', got '%s'", capturedID)
	}
}

func TestRouteParamsWithoutMiddleware(t *testing.T) {
	r := router.New()

	var capturedID string

	// Register route WITHOUT middleware - this works fine
	r.Get("/users/{userID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		capturedID = chi.URLParam(r, "userID")
		w.WriteHeader(http.StatusOK)
	}))

	req := httptest.NewRequest("GET", "/users/456", nil)
	rec := httptest.NewRecorder()

	r.ServeHTTP(rec, req)

	if rec.Code != http.StatusOK {
		t.Fatalf("expected status 200, got %d", rec.Code)
	}

	if capturedID != "456" {
		t.Errorf("expected userID to be '456', got '%s'", capturedID)
	}
}

func TestNestedRouteParamsWithMiddleware(t *testing.T) {
	r := router.New()

	nopMiddleware := func(next http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			next.ServeHTTP(w, r)
		})
	}

	var capturedSiteID, capturedRecipeID string

	// Test nested routes like /v1/recipes/{siteID}/recipes/{recipeID}
	r.Route("/v1/recipes", func(r router.Router) {
		r.Get("/{siteID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			capturedSiteID = chi.URLParam(r, "siteID")
			w.WriteHeader(http.StatusOK)
		}), nopMiddleware)

		r.Get("/{siteID}/{recipeID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			capturedSiteID = chi.URLParam(r, "siteID")
			capturedRecipeID = chi.URLParam(r, "recipeID")
			w.WriteHeader(http.StatusOK)
		}), nopMiddleware)
	})

	// Test single param
	req1 := httptest.NewRequest("GET", "/v1/recipes/site-abc", nil)
	rec1 := httptest.NewRecorder()
	r.ServeHTTP(rec1, req1)

	if rec1.Code != http.StatusOK {
		t.Fatalf("expected status 200, got %d", rec1.Code)
	}
	if capturedSiteID != "site-abc" {
		t.Errorf("expected siteID to be 'site-abc', got '%s'", capturedSiteID)
	}

	// Test multiple params
	capturedSiteID, capturedRecipeID = "", ""
	req2 := httptest.NewRequest("GET", "/v1/recipes/site-xyz/recipe-789", nil)
	rec2 := httptest.NewRecorder()
	r.ServeHTTP(rec2, req2)

	if rec2.Code != http.StatusOK {
		t.Fatalf("expected status 200, got %d", rec2.Code)
	}
	if capturedSiteID != "site-xyz" {
		t.Errorf("expected siteID to be 'site-xyz', got '%s'", capturedSiteID)
	}
	if capturedRecipeID != "recipe-789" {
		t.Errorf("expected recipeID to be 'recipe-789', got '%s'", capturedRecipeID)
	}
}
```

## Backwards Compatibility

The fix is fully backwards compatible:

1. **No API changes** - All method signatures remain identical
2. **Middleware order preserved** - The `chain()` helper applies middlewares in the same order as chi's `.With()`
3. **Existing behavior maintained** - Routes without middlewares work exactly as before
4. **Only fixes broken behavior** - Routes with middlewares now correctly set up chi's route context

## Additional Notes

- The bug only manifests when using **per-route middlewares** (the `mws` parameter)
- Routes registered without middlewares work fine
- Router-level middlewares (via `r.Use()`) are not affected by this bug
- The fix ensures chi's route context is properly initialized, enabling `chi.URLParam()`, `chi.RouteContext()`, and related functions to work correctly

## Important: Chi Version Consistency

The router wrapper imports `github.com/go-chi/chi/v5`. **You must use the same chi version in your application code**, otherwise you'll encounter a separate issue:

- If your code imports `github.com/go-chi/chi` (v1) and calls `chi.URLParam()`, it looks for v1's route context
- But the router wrapper sets up v5's route context
- These are incompatible, so `chi.URLParam()` returns empty string even when the route context is correctly set up

**Solution**: Import `github.com/go-chi/chi/v5` consistently in all your code that uses chi functions like `chi.URLParam()`, `chi.RouteContext()`, etc.

This version mismatch can mask the middleware bug described above, making it appear that routes without middlewares work fine (they actually don't - the version mismatch affects all routes). Always ensure chi version consistency when using this wrapper.
