### PR TITLE
Add Router.Bind to mount a Module at a path prefix

### DIFF
--- a/web/module.go
+++ b/web/module.go
@@ -4,6 +4,4 @@ import "github.com/jimmysawczuk/kit/web/router"
 
 // Module is a set of endpoints that can be naturally grouped together. A module can evaluate its own health
 // and can attach itself to a Router.
-type Module interface {
-	Route(router.Router)
-}
+type Module = router.Module

--- a/web/router/router.go
+++ b/web/router/router.go
@@ -8,6 +8,10 @@ import (
 
 type Middleware = func(http.Handler) http.Handler
 
+type Module interface {
+	Route(Router)
+}
+
 type Router interface {
 	http.Handler
 
@@ -35,6 +39,7 @@ type Router interface {
 	Group(func(Router), ...Middleware)
 	Route(string, func(Router), ...Middleware)
 	Mount(string, http.Handler, ...Middleware)
+	Bind(string, Module, ...Middleware)
 
 	Routes() []Route
 }
@@ -159,6 +164,12 @@ func (ro chiRouter) Route(path string, f func(Router), mws ...Middleware) {
 		rr.Use(mws...)
 		f(rr)
 	})
+}
+
+func (ro chiRouter) Bind(prefix string, m Module, mws ...Middleware) {
+	ro.Route(prefix, func(r Router) {
+		m.Route(r)
+	}, mws...)
 }
 
 func (ro chiRouter) Mount(path string, h http.Handler, mws ...Middleware) {

--- a/web/router/router_test.go
+++ b/web/router/router_test.go
@@ -67,6 +67,63 @@ func TestRouteParamsWithoutMiddleware(t *testing.T) {
 	}
 }
 
+type authModule struct{}
+
+func (m authModule) Route(r router.Router) {
+	r.Getf("/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Getf("/logout", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func TestBind(t *testing.T) {
+	r := router.New()
+	r.Bind("/v1/auth", authModule{})
+
+	for _, tt := range []struct {
+		path string
+		want int
+	}{
+		{"/v1/auth/login", http.StatusOK},
+		{"/v1/auth/logout", http.StatusNoContent},
+		{"/v1/auth/missing", http.StatusNotFound},
+	} {
+		req := httptest.NewRequest("GET", tt.path, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != tt.want {
+			t.Errorf("GET %s: expected %d, got %d", tt.path, tt.want, rec.Code)
+		}
+	}
+}
+
+func TestBindWithMiddleware(t *testing.T) {
+	r := router.New()
+
+	var middlewareCalled bool
+	trackMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			middlewareCalled = true
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	r.Bind("/v1/auth", authModule{}, trackMiddleware)
+
+	req := httptest.NewRequest("GET", "/v1/auth/login", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if !middlewareCalled {
+		t.Error("expected middleware to be called")
+	}
+}
+
 func TestNestedRouteParamsWithMiddleware(t *testing.T) {
 	r := router.New()
 


### PR DESCRIPTION
## Summary

- Defines a `Module` interface in the `router` package (`Route(Router)`)
- Adds `Bind(prefix string, m Module, mws ...Middleware)` to the `Router` interface and `chiRouter` implementation
- `web.Module` is now a type alias for `router.Module`, keeping existing code fully compatible

## Test plan

- `TestBind` — verifies routes registered by a module are reachable under the bound prefix, and unregistered paths return 404
- `TestBindWithMiddleware` — verifies middleware passed to `Bind` is applied to requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)