### PR TITLE
web: fix six bugs

### DIFF
--- a/web/app.go
+++ b/web/app.go
@@ -73,9 +73,7 @@ func (a *App) WithHealthCheck(h HealthChecker) *App {
 }
 
 func (a *App) WithHealthCheckHandler(path string, mws ...Middleware) *App {
-	a.router.Get(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		HealthCheckHandler(a.hc...).ServeHTTP(w, r)
-	}))
+	a.router.Get(path, HealthCheckHandler(a.hc...), mws...)
 	return a
 }
 

--- a/web/healthcheck_handler.go
+++ b/web/healthcheck_handler.go
@@ -14,7 +14,7 @@ import (
 // emitting a 503 if any return an error or the check cannot complete within the specified duration. If timeout <= 0,
 // there is no timeout.
 func HealthCheckHandler(hc ...HealthChecker) Handler {
-	return func(ctx context.Context, l *zerolog.Logger, w http.ResponseWriter, r *http.Request) {
+	return func(ctx context.Context, log *zerolog.Logger, w http.ResponseWriter, r *http.Request) {
 		m := sync.Map{}
 
 		wg := sync.WaitGroup{}
@@ -27,7 +27,7 @@ func HealthCheckHandler(hc ...HealthChecker) Handler {
 			go func() {
 				err := h.HealthCheck(ctx)
 				if err != nil {
-					l.Error().
+					log.Error().
 						Err(err).
 						Type("type", h).
 						Str("name", h.Name()).

--- a/web/healthcheck_handler.go
+++ b/web/healthcheck_handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jimmysawczuk/kit/web/respond"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Health is a Handler checks the health of the App by checking all of the app's HealthCheckers sequentially,
@@ -28,7 +27,7 @@ func HealthCheckHandler(hc ...HealthChecker) Handler {
 			go func() {
 				err := h.HealthCheck(ctx)
 				if err != nil {
-					log.Error().
+					l.Error().
 						Err(err).
 						Type("type", h).
 						Str("name", h.Name()).
@@ -45,7 +44,7 @@ func HealthCheckHandler(hc ...HealthChecker) Handler {
 
 		go func() {
 			wg.Wait()
-			wgDone <- struct{}{}
+			close(wgDone)
 		}()
 
 		healthy := true

--- a/web/middleware/timeout.go
+++ b/web/middleware/timeout.go
@@ -1,11 +1,10 @@
 package middleware
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	rdebug "runtime/debug"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jimmysawczuk/kit/web/respond"
@@ -50,19 +49,13 @@ func WithTimeout(timeout time.Duration) func(http.Handler) http.Handler {
 
 			select {
 			case <-doneCh:
-				tw.mx.Lock()
-				tw.done = true
-				tw.mx.Unlock()
+				tw.done.Store(true)
 			case <-time.After(timeout):
-				tw.mx.Lock()
-				respond.Error(ctx, http.StatusGatewayTimeout, fmt.Errorf("timed out after %s", timeout))
-				tw.done = true
-				tw.mx.Unlock()
+				respond.Error(ctx, http.StatusGatewayTimeout, fmt.Errorf("timed out after %s", timeout)).Write(w)
+				tw.done.Store(true)
 			case perr := <-panicCh:
-				tw.mx.Lock()
-				respond.Error(ctx, http.StatusInternalServerError, perr)
-				tw.done = true
-				tw.mx.Unlock()
+				respond.Error(ctx, http.StatusInternalServerError, perr).Write(w)
+				tw.done.Store(true)
 			}
 		})
 	}
@@ -73,14 +66,13 @@ func WithTimeout(timeout time.Duration) func(http.Handler) http.Handler {
 type timeoutWriter struct {
 	http.ResponseWriter
 
-	mx   sync.Mutex
-	done bool
+	done atomic.Bool
 }
 
 // Header implements http.ResponseWriter. If we haven't timed out yet, proxy this to the normal ResponseWriter.
 // Otherwise, fake it.
 func (tw *timeoutWriter) Header() http.Header {
-	if tw.done {
+	if tw.done.Load() {
 		return map[string][]string{}
 	}
 
@@ -90,7 +82,7 @@ func (tw *timeoutWriter) Header() http.Header {
 // WriteHeader implements http.ResponseWriter. If we haven't timed out yet, proxy this to the normal ResponseWriter.
 // Otherwise, fake it.
 func (tw *timeoutWriter) WriteHeader(status int) {
-	if tw.done {
+	if tw.done.Load() {
 		return
 	}
 
@@ -98,10 +90,10 @@ func (tw *timeoutWriter) WriteHeader(status int) {
 }
 
 // Write implements http.ResponseWriter. If we haven't timed out yet, proxy this to the normal ResponseWriter.
-// Otherwise, this returns an error saying the time for writing has passed.
+// Otherwise, this is a no-op.
 func (tw *timeoutWriter) Write(b []byte) (int, error) {
-	if tw.done {
-		return 0, errors.New("ResponseWriter already written")
+	if tw.done.Load() {
+		return 0, nil
 	}
 
 	return tw.ResponseWriter.Write(b)

--- a/web/respond/respond_test.go
+++ b/web/respond/respond_test.go
@@ -212,10 +212,12 @@ func TestRespondWithErrorSuppressed(t *testing.T) {
 		},
 	}
 
+	orig := respond.DefaultResponder
+	respond.DefaultResponder = &respond.JSONResponder{SuppressErrors: true}
+	t.Cleanup(func() { respond.DefaultResponder = orig })
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			respond.DefaultResponder = &respond.JSONResponder{SuppressErrors: true}
-
 			srv := httptest.NewServer(test.handler)
 			defer srv.Close()
 

--- a/web/shutdown.go
+++ b/web/shutdown.go
@@ -77,7 +77,7 @@ func Shutdown(timeout time.Duration, log *zerolog.Logger, sig chan os.Signal, st
 
 	go func() {
 		wg.Wait()
-		wgDone <- struct{}{}
+		close(wgDone)
 	}()
 
 	select {


### PR DESCRIPTION
Addresses the bugs section of #14.

## Changes

**`middleware/timeout.go`**
- Timeout and panic branches were calling `respond.Error(...)` but never `.Write(w)` — the 504/500 was silently discarded and the client received whatever the handler wrote before the deadline (or an empty 200)
- `timeoutWriter.done` was read in `Write`/`WriteHeader`/`Header` without synchronization while the select branch wrote it under a mutex — replaced `sync.Mutex` + `bool` with `atomic.Bool`

**`app.go`**
- `WithHealthCheckHandler` accepted `mws ...Middleware` but never passed them to the route registration; also removed the redundant `http.HandlerFunc` wrapper since `HealthCheckHandler` already returns an `http.Handler`

**`shutdown.go` / `healthcheck_handler.go`**
- Both sent `struct{}{}` on an unbuffered `wgDone` channel inside a goroutine; if the other `select` case fired first the goroutine blocked forever, leaking it — use `close(wgDone)` instead

**`healthcheck_handler.go`**
- Was calling the package-level `log.Error()` instead of the per-request logger `l`, so health check failures were missing request-id, method, and other context fields

**`respond/respond_test.go`**
- `TestRespondWithErrorSuppressed` mutated `respond.DefaultResponder` inside each subtest without restoring it, causing order-dependent failures — moved the assignment before the loop with a `t.Cleanup` to restore the original

## Test plan

- [ ] `go test ./web/...` passes